### PR TITLE
Add __hash__ to DistributionPackage

### DIFF
--- a/src/pypi_simple/classes.py
+++ b/src/pypi_simple/classes.py
@@ -80,6 +80,10 @@ class DistributionPackage:
     #: mapping from hash algorithm names to hex-encoded digest strings;
     #: otherwise, it is `None`
     metadata_digests: Optional[dict[str, str]] = None
+        
+        
+    def __hash__(self):
+        return hash(self.filename) + hash(self.url)
 
     @property
     def sig_url(self) -> str:


### PR DESCRIPTION
Makes DistributionPackage hashable, so it can be added to sets without monkey-patching.