### PR TITLE
Use instance-default accept in get_project_page

### DIFF
--- a/src/pypi_simple/client.py
+++ b/src/pypi_simple/client.py
@@ -238,7 +238,7 @@ class PyPISimple:
             greater major component than the supported repository version
         """
         url = self.get_project_url(project)
-        r = self.s.get(url, timeout=timeout, headers={"Accept": accept or None})
+        r = self.s.get(url, timeout=timeout, headers={"Accept": accept or self.accept})
         if r.status_code == 404:
             raise NoSuchProjectError(project, url)
         r.raise_for_status()


### PR DESCRIPTION
This appears to be an oversight in the commit where instance-default accept was added.  The docstring for the method says it should be this way :)