### PR TITLE
Always consider metadata as utf-8.

### DIFF
--- a/src/pypi_simple/client.py
+++ b/src/pypi_simple/client.py
@@ -328,6 +328,59 @@ class PyPISimple:
                         pass
                 raise
 
+    def get_package_metadata_bytes(
+        self,
+        pkg: DistributionPackage,
+        verify: bool = True,
+        timeout: float | tuple[float, float] | None = None,
+    ) -> bytes:
+        """
+        .. versionadded:: 1.5.0
+
+        Retrieve the `distribution metadata`_ for the given
+        `DistributionPackage`.  This method is lower-level than
+        `PyPISimple.get_package_metadata` and is most appropriate if you want
+        to defer interpretation of the data (e.g. if you're just writing to a
+        file) or want to customize the handling of non-``utf-8`` data.
+
+        Not all packages have distribution metadata available for download; the
+        `DistributionPackage.has_metadata` attribute can be used to check
+        whether the repository reported the availability of the metadata.  This
+        method will always attempt to download metadata regardless of the value
+        of `~DistributionPackage.has_metadata`; if the server replies with a
+        404, a `NoMetadataError` is raised.
+
+        :param DistributionPackage pkg:
+            the distribution package to retrieve the metadata of
+        :param bool verify:
+            whether to verify the metadata's digests against the retrieved data
+        :param timeout: optional timeout to pass to the ``requests`` call
+        :type timeout: float | tuple[float,float] | None
+
+        :raises NoMetadataError:
+            if the repository responds with a 404 error code
+        :raises requests.HTTPError: if the repository responds with an HTTP
+            error code other than 404
+        :raises NoDigestsError:
+            if ``verify`` is true and the given package's metadata does not
+            have any digests with known algorithms
+        :raises DigestMismatchError:
+            if ``verify`` is true and the digest of the downloaded data does
+            not match the expected value
+        """
+        digester: AbstractDigestChecker
+        if verify:
+            digester = DigestChecker(pkg.metadata_digests or {})
+        else:
+            digester = NullDigestChecker()
+        r = self.s.get(pkg.metadata_url, timeout=timeout)
+        if r.status_code == 404:
+            raise NoMetadataError(pkg.filename)
+        r.raise_for_status()
+        digester.update(r.content)
+        digester.finalize()
+        return r.content
+
     def get_package_metadata(
         self,
         pkg: DistributionPackage,
@@ -372,18 +425,11 @@ class PyPISimple:
             if ``verify`` is true and the digest of the downloaded data does
             not match the expected value
         """
-        digester: AbstractDigestChecker
-        if verify:
-            digester = DigestChecker(pkg.metadata_digests or {})
-        else:
-            digester = NullDigestChecker()
-        r = self.s.get(pkg.metadata_url, timeout=timeout)
-        if r.status_code == 404:
-            raise NoMetadataError(pkg.filename)
-        r.raise_for_status()
-        digester.update(r.content)
-        digester.finalize()
-        return r.content.decode("utf-8")
+        return self.get_package_metadata_bytes(
+            pkg,
+            verify,
+            timeout,
+        ).decode("utf-8", "surrogateescape")
 
 
 class NoSuchProjectError(Exception):

--- a/src/pypi_simple/client.py
+++ b/src/pypi_simple/client.py
@@ -383,7 +383,7 @@ class PyPISimple:
         r.raise_for_status()
         digester.update(r.content)
         digester.finalize()
-        return r.text
+        return r.content.decode("utf-8")
 
 
 class NoSuchProjectError(Exception):


### PR DESCRIPTION
This is documented near the beginning of
https://packaging.python.org/en/latest/specifications/core-metadata/ and warehouse currently serves these as `content-type: application/octet-stream` with no encoding, so requests spends a surprising amount of time on what are generally lower-ascii files trying to guess an encoding.

I think this is 100% safe -- files that can't be understood as utf-8 appear to not work in pip, which [reads them as bytes](https://github.com/pypa/pip/blob/51de88ca6459fdd5213f86a54b021a80884572f9/src/pip/_internal/operations/prepare.py#L396), [saves them as bytes](https://github.com/pypa/pip/blob/51de88ca6459fdd5213f86a54b021a80884572f9/src/pip/_internal/metadata/importlib/_dists.py#L124) and importlib [always uses utf-8](https://github.com/python/cpython/blob/d08d5b62517c71a7f8781a6b2d3520a0e4bf7b19/Lib/importlib/metadata/__init__.py#L818).  A better API for pypi-simple might be to return bytes, but that's more disruptive.

Sample debug log [pydantic-2.6.1-py3-none-any.whl.metadata](https://files.pythonhosted.org/packages/db/dc/afecbd9650f486889181c6d1a0d675b580c06253ea7e304588e4c7485bdb/pydantic-2.6.1-py3-none-any.whl.metadata) showing more than 300ms spent trying to load the thing, only to give up and treat it as utf-8 anyway.

```
2024-02-16 16:24:06,001 DEBUG    chardet.charsetprober:65 SHIFT_JIS Japanese prober hit error at byte 74979
2024-02-16 16:24:06,047 DEBUG    chardet.charsetprober:66 EUC-JP Japanese prober hit error at byte 50943
2024-02-16 16:24:06,075 DEBUG    chardet.charsetprober:64 GB2312 Chinese prober hit error at byte 52901
2024-02-16 16:24:06,103 DEBUG    chardet.charsetprober:64 EUC-KR Korean prober hit error at byte 50943
2024-02-16 16:24:06,130 DEBUG    chardet.charsetprober:64 CP949 Korean prober hit error at byte 50943
2024-02-16 16:24:06,158 DEBUG    chardet.charsetprober:64 Big5 Chinese prober hit error at byte 50944
2024-02-16 16:24:06,185 DEBUG    chardet.charsetprober:64 EUC-TW Taiwan prober hit error at byte 50943
2024-02-16 16:24:06,214 DEBUG    chardet.charsetprober:64 Johab Korean prober hit error at byte 52901
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 windows-1251 Russian confidence = 0.01
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 KOI8-R Russian confidence = 0.01
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 ISO-8859-5 Russian confidence = 0.0
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 MacCyrillic Russian confidence = 0.0
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 IBM866 Russian confidence = 0.02409316779801155
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 IBM855 Russian confidence = 0.0
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 ISO-8859-7 Greek confidence = 0.0
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 windows-1253 Greek confidence = 0.0
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 ISO-8859-5 Bulgarian confidence = 0.0
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 windows-1251 Bulgarian confidence = 0.01
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 TIS-620 Thai confidence = 0.01
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 ISO-8859-9 Turkish confidence = 0.5782542205214045
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 windows-1255 Hebrew confidence = 0.0
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 windows-1255 Hebrew confidence = 0.01
2024-02-16 16:24:06,314 DEBUG    chardet.charsetprober:98 windows-1255 Hebrew confidence = 0.01
```

You might not notice this in a normal application, but I'm fetching these in a loop, with [cachecontrol](https://pypi.org/project/CacheControl/) as the session, with a hot cache.

Here are traces for this change (the green block is `get_package_metadata` and the total time is visible top-right):

Before:

![image](https://github.com/jwodder/pypi-simple/assets/49834/471cb6e0-ef92-4d7b-b223-ac86ca5e69ff)

After:

![image](https://github.com/jwodder/pypi-simple/assets/49834/5425af87-3217-43f5-bf10-1c21060149b6)