### PR TITLE
Support `data-core-metadata="true"`

### DIFF
--- a/src/pypi_simple/classes.py
+++ b/src/pypi_simple/classes.py
@@ -149,7 +149,7 @@ class DistributionPackage:
             m = re.fullmatch(r"(\w+)=([0-9A-Fa-f]+)", mddigest)
             if m:
                 metadata_digests[m[1]] = m[2]
-            has_metadata = bool(m) or mddigest == "true"
+            has_metadata = bool(m) or mddigest.lower() == "true"
         else:
             metadata_digests = None
         yanked_reason = link.get_str_attrib("data-yanked")

--- a/src/pypi_simple/classes.py
+++ b/src/pypi_simple/classes.py
@@ -143,11 +143,13 @@ class DistributionPackage:
             has_sig = None
         mddigest = link.get_str_attrib("data-core-metadata")
         metadata_digests: Optional[dict[str, str]]
+        has_metadata = None
         if mddigest is not None:
             metadata_digests = {}
             m = re.fullmatch(r"(\w+)=([0-9A-Fa-f]+)", mddigest)
             if m:
                 metadata_digests[m[1]] = m[2]
+            has_metadata = bool(m) or mddigest == "true"
         else:
             metadata_digests = None
         yanked_reason = link.get_str_attrib("data-yanked")
@@ -163,7 +165,7 @@ class DistributionPackage:
             yanked_reason=yanked_reason,
             digests=digests,
             metadata_digests=metadata_digests,
-            has_metadata=metadata_digests is not None,
+            has_metadata=has_metadata,
         )
 
     @classmethod

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -91,7 +91,7 @@ def test_session(mocker: MockerFixture, content_type: str) -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
                 DistributionPackage(
                     filename="in_place-0.1.1.tar.gz",
@@ -107,7 +107,7 @@ def test_session(mocker: MockerFixture, content_type: str) -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
                 DistributionPackage(
                     filename="in_place-0.2.0-py2.py3-none-any.whl",
@@ -123,7 +123,7 @@ def test_session(mocker: MockerFixture, content_type: str) -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
                 DistributionPackage(
                     filename="in_place-0.2.0.tar.gz",
@@ -139,7 +139,7 @@ def test_session(mocker: MockerFixture, content_type: str) -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
                 DistributionPackage(
                     filename="in_place-0.3.0-py2.py3-none-any.whl",
@@ -155,7 +155,7 @@ def test_session(mocker: MockerFixture, content_type: str) -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
                 DistributionPackage(
                     filename="in_place-0.3.0.tar.gz",
@@ -171,7 +171,7 @@ def test_session(mocker: MockerFixture, content_type: str) -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
             ],
             last_serial="54321",
@@ -220,7 +220,7 @@ def test_project_hint_received() -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
                 DistributionPackage(
                     filename="aws-adfs-ebsco-0.3.7-1.tar.gz",
@@ -236,7 +236,7 @@ def test_project_hint_received() -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
             ],
             last_serial=None,
@@ -296,7 +296,7 @@ def test_redirected_project_page() -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
             ],
             last_serial=None,
@@ -340,7 +340,7 @@ def test_utf8_declarations(content_type: str, body_decl: bytes) -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
             ],
             last_serial=None,
@@ -387,7 +387,7 @@ def test_latin2_declarations(content_type: str, body_decl: bytes) -> None:
                     is_yanked=False,
                     yanked_reason=None,
                     metadata_digests=None,
-                    has_metadata=False,
+                    has_metadata=None,
                 ),
             ],
             last_serial=None,
@@ -630,7 +630,7 @@ def test_download(tmp_path: Path) -> None:
             is_yanked=False,
             yanked_reason=None,
             metadata_digests=None,
-            has_metadata=False,
+            has_metadata=None,
         )
         dest = tmp_path / str(pkg.project) / pkg.filename
         simple.download_package(pkg, dest)
@@ -660,7 +660,7 @@ def test_download_no_digests(tmp_path: Path) -> None:
             is_yanked=False,
             yanked_reason=None,
             metadata_digests=None,
-            has_metadata=False,
+            has_metadata=None,
         )
         dest = tmp_path / str(pkg.project) / pkg.filename
         with pytest.raises(NoDigestsError) as excinfo:
@@ -692,7 +692,7 @@ def test_download_bad_digests(tmp_path: Path) -> None:
             is_yanked=False,
             yanked_reason=None,
             metadata_digests=None,
-            has_metadata=False,
+            has_metadata=None,
         )
         dest = tmp_path / str(pkg.project) / pkg.filename
         with pytest.raises(DigestMismatchError) as excinfo:
@@ -729,7 +729,7 @@ def test_download_bad_digests_keep(tmp_path: Path) -> None:
             is_yanked=False,
             yanked_reason=None,
             metadata_digests=None,
-            has_metadata=False,
+            has_metadata=None,
         )
         dest = tmp_path / str(pkg.project) / pkg.filename
         with pytest.raises(DigestMismatchError) as excinfo:
@@ -774,7 +774,7 @@ def test_download_bad_digests_no_verify(
             is_yanked=False,
             yanked_reason=None,
             metadata_digests=None,
-            has_metadata=False,
+            has_metadata=None,
         )
         dest = tmp_path / str(pkg.project) / pkg.filename
         simple.download_package(pkg, dest, verify=False)
@@ -830,7 +830,7 @@ def test_download_progress(tmp_path: Path) -> None:
             is_yanked=False,
             yanked_reason=None,
             metadata_digests=None,
-            has_metadata=False,
+            has_metadata=None,
         )
         dest = tmp_path / str(pkg.project) / pkg.filename
         spy = SpyingProgressTracker()

--- a/test/test_distrib_pkg.py
+++ b/test/test_distrib_pkg.py
@@ -84,7 +84,7 @@ def test_get_sig_url(has_sig: bool) -> None:
                 is_yanked=False,
                 yanked_reason=None,
                 metadata_digests=None,
-                has_metadata=False,
+                has_metadata=None,
             ),
         ),
         (
@@ -123,7 +123,7 @@ def test_get_sig_url(has_sig: bool) -> None:
                 url="https://files.pythonhosted.org/packages/82/fc/9e25534641d7f63be93079bc07fa92bab136ddf5d4181059a1308a346f96/qypi-0.1.0-py3-none-any.whl#sha256=da69d28dcd527c0e372b3fa7b92fc333b327f8470175f035abc4e351b539189f",
                 attrs={
                     "data-gpg-sig": "false",
-                    "data-core-metadata": "sha256=true",
+                    "data-core-metadata": "true",
                 },
             ),
             DistributionPackage(

--- a/test/test_project_page.py
+++ b/test/test_project_page.py
@@ -47,7 +47,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.tar.gz",
@@ -63,7 +63,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.post1-py3-none-any.whl",
@@ -79,7 +79,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.post1.tar.gz",
@@ -95,7 +95,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.2.0-py3-none-any.whl",
@@ -111,7 +111,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.2.0.tar.gz",
@@ -127,7 +127,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.3.0-py3-none-any.whl",
@@ -143,7 +143,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.3.0.tar.gz",
@@ -159,7 +159,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.4.0-py3-none-any.whl",
@@ -175,7 +175,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.4.0.tar.gz",
@@ -191,7 +191,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.4.1-py3-none-any.whl",
@@ -207,7 +207,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.4.1.tar.gz",
@@ -223,7 +223,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                 ],
                 repository_version=None,
@@ -252,7 +252,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.tar.gz",
@@ -268,7 +268,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.post1-py3-none-any.whl",
@@ -284,7 +284,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.post1.tar.gz",
@@ -300,7 +300,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                 ],
                 repository_version=None,
@@ -329,7 +329,7 @@ def test_from_html_empty() -> None:
                         is_yanked=True,
                         yanked_reason="Metadata was smelly",
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.tar.gz",
@@ -345,7 +345,7 @@ def test_from_html_empty() -> None:
                         is_yanked=True,
                         yanked_reason="",
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.post1-py3-none-any.whl",
@@ -361,7 +361,7 @@ def test_from_html_empty() -> None:
                         is_yanked=True,
                         yanked_reason="",
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.post1.tar.gz",
@@ -377,7 +377,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.2.0-py3-none-any.whl",
@@ -393,7 +393,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                 ],
                 repository_version=None,
@@ -422,7 +422,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.tar.gz",
@@ -438,7 +438,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                 ],
                 repository_version="1.0",
@@ -467,7 +467,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="qypi-0.1.0.tar.gz",
@@ -483,7 +483,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                 ],
                 repository_version="1.2",
@@ -520,7 +520,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="devpi-2.1.0.tar.gz",
@@ -536,7 +536,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="devpi-2.0.3.tar.gz",
@@ -552,7 +552,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="devpi-2.0.2.tar.gz",
@@ -568,7 +568,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                     DistributionPackage(
                         filename="devpi-2.0.1.tar.gz",
@@ -584,7 +584,7 @@ def test_from_html_empty() -> None:
                         is_yanked=False,
                         yanked_reason=None,
                         metadata_digests=None,
-                        has_metadata=False,
+                        has_metadata=None,
                     ),
                 ],
                 repository_version=None,


### PR DESCRIPTION
PEP 658 says:

```
The repository SHOULD provide the hash of the Core Metadata file as the
data-dist-info-metadata attribute’s value using the syntax
<hashname>=<hashvalue>, where <hashname> is the lower cased name of the hash
function used, and <hashvalue> is the hex encoded digest. The repository MAY
use true as the attribute’s value if a hash is unavailable.
```

My read of this is that the "true" part would be
`data-dist-info-metadata="true"`, not
`data-dist-info-metadata="<hashname>=true"` which is what the current code understands.

This is a little nitpicky becuase Warehouse currently doesn't ever generate the value `true`, but I was thinking about doing so as an optimization in an alternate simple index.

This change obeys the intent of the comment for `has_metadata` which is less ambiguous for the JSON API:

> Whether the package file is accompanied by a Core Metadata file.  This
> is `None` if the package repository does not report such information.

Because Warehouse only provides `true`, `<hashname>=<hashvalue`, or omits entirely, this now maps omit to `None` instead of `False`.  If this is incorrect we should probably make the comment say something different.  PEP 658 doesn't say anything about a `false` value in HTML.