### PR TITLE
Drop `typing_extensions` dependendency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
     "packaging >= 20",
     "pydantic ~= 2.0",
     "requests ~= 2.20",
-    "typing_extensions; python_version < '3.8'",
 ]
 
 [project.optional-dependencies]

--- a/src/pypi_simple/progress.py
+++ b/src/pypi_simple/progress.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 from collections.abc import Callable
-import sys
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Optional
-
-if sys.version_info[:2] >= (3, 8):
-    from typing import Protocol, runtime_checkable
-else:
-    from typing_extensions import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from typing_extensions import Self


### PR DESCRIPTION
No longer needed now that Python 3.7 is no longer supported