### PR TITLE
Add a warning about the caching of the top level page

### DIFF
--- a/src/pypi_simple/client.py
+++ b/src/pypi_simple/client.py
@@ -119,7 +119,7 @@ class PyPISimple:
         .. warning::
 
             PyPI's top-level simple HTML page is cached for 24 hours, meaning
-            that new projects won't show up on this page immediate.  Access
+            that new projects won't show up on this page immediately.  Access
             the project page directly if you need immediate results.
 
         .. versionchanged:: 1.0.0

--- a/src/pypi_simple/client.py
+++ b/src/pypi_simple/client.py
@@ -116,6 +116,12 @@ class PyPISimple:
             PyPI's project index file is very large and takes several seconds
             to parse.  Use this method sparingly.
 
+        .. warning::
+
+            PyPI's top-level simple HTML page is cached for 24 hours, meaning
+            that new projects won't show up on this page immediate.  Access
+            the project page directly if you need immediate results.
+
         .. versionchanged:: 1.0.0
 
             ``accept`` parameter added


### PR DESCRIPTION
I've confirmed with Ee that the top level simple index page on PyPI is cached for 24 hours.  It was odd because a project we created and uploaded the first package of was not showing up.  It does show up in the project page.  I thought it would be helpful at least to add a warning to do this package's doc (it's the library I was using when I found this).